### PR TITLE
Removed .vim file extensions.

### DIFF
--- a/autoload/fzf_session.vim
+++ b/autoload/fzf_session.vim
@@ -16,7 +16,7 @@ endfunction
 
 " Return a session file path from its name {{{
 function! s:session_file(name)
-    let l:file = fzf_session#path()."/".a:name.".vim"
+    let l:file = fzf_session#path()."/".a:name
     return fnamemodify(expand(l:file), ':p')
 endfunction
 "}}}
@@ -79,7 +79,7 @@ endfunction
 function! fzf_session#list()
     let l:wildignore=&wildignore
     set wildignore=
-    let l:session_files = split(globpath(fzf_session#path(), "*.vim"))
+    let l:session_files = split(globpath(fzf_session#path(), "*"))
     let l:result = map(l:session_files, "fnamemodify(expand(v:val), ':t:r')")
     let &wildignore = l:wildignore
     return l:result


### PR DESCRIPTION
By removing the .vim file extensions, you make this plugin compatible with [vim-startify](https://github.com/mhinz/vim-startify), which lets you select a session when you start vim. However, with the .vim extensions, it tries to start session_name.vim.vim. Furthermore, this change allows tmux users to use [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) to restore vim sessions.

Furthermore, I would consider making the default session directory ~/.vim/session, which is used by other session plugins. It would also make it work out of the box with vim-startify and tmux-resurrect.