### PR TITLE
Fix behaviour when session path is missing

### DIFF
--- a/autoload/fzf_session.vim
+++ b/autoload/fzf_session.vim
@@ -8,7 +8,7 @@
 " Return sessions location path {{{
 function! fzf_session#path()
     if !exists('g:fzf_session_path')
-        return expand('%:h')
+        return expand('%:hp')
     endif
     return g:fzf_session_path
 endfunction

--- a/autoload/fzf_session.vim
+++ b/autoload/fzf_session.vim
@@ -8,7 +8,7 @@
 " Return sessions location path {{{
 function! fzf_session#path()
     if !exists('g:fzf_session_path')
-        return expand('%:.')
+        return expand('%:h')
     endif
     return g:fzf_session_path
 endfunction


### PR DESCRIPTION
Poor expansion of a fallback variable when g:fzf_session_path wasn't set resulted in an error. This pull request expands the default path to be the containing directory of the current file.

Closes #3 
