### PR TITLE
Fix a SList bug when file name contains white space

### DIFF
--- a/autoload/fzf_session.vim
+++ b/autoload/fzf_session.vim
@@ -79,7 +79,7 @@ endfunction
 function! fzf_session#list()
     let l:wildignore=&wildignore
     set wildignore=
-    let l:session_files = split(globpath(fzf_session#path(), "*"))
+    let l:session_files = split(globpath(fzf_session#path(), "*"), "\n")
     let l:result = map(l:session_files, "fnamemodify(expand(v:val), ':t:r')")
     let &wildignore = l:wildignore
     return l:result


### PR DESCRIPTION
when filename contains whitespace, the split function also splits the file name.